### PR TITLE
Inject delta

### DIFF
--- a/truth.mjs
+++ b/truth.mjs
@@ -6,7 +6,7 @@ export default function truth(...ops)
 	send=function(act)
 	{
 		act=truth.inject(state,truth.compose(pre,act))
-		return act?new Promise(res=>res(truth.compose(post,act))):0
+		return act?new Promise(res=>res(truth.compose(post,act))):act
 	}//promise prevents holding up subsequent code
 	send({type:'set',path:[],val:state})
 	return truth.proxy(send,state)

--- a/truth.mjs
+++ b/truth.mjs
@@ -6,21 +6,23 @@ export default function truth(...ops)
 	send=function(act)
 	{
 		act=truth.inject(state,truth.compose(pre,act))
-		return new Promise(res=>res(truth.compose(post,act)))
+		return act?new Promise(res=>res(truth.compose(post,act))):0
 	}//promise prevents holding up subsequent code
 	send({type:'set',path:[],val:state})
 	return truth.proxy(send,state)
 }
-truth.inject=function(state,{path,type,val})
 truth.compose=(fns,...args)=>fns.reduce((arg,fn)=>fn(...arg),args)
+truth.inject=function(state,act)
 {
-	if(!type) return
+	if(!act.type) return
 	const
+	{path,type,val}=act,
 	[props,prop]=truth.zipList(path,path.length-1),
 	ref=truth.ref(state,props)
 	type==='del'?delete ref[prop]:
 	type==='set'&&path.length?ref[prop]=val:
 	state=val
+	return act
 }
 truth.proxy=function(send,obj,path=[])
 {

--- a/truth.mjs
+++ b/truth.mjs
@@ -5,13 +5,14 @@ export default function truth(...ops)
 	[pre,state,post]=truth.zipList(ops,i),
 	send=function(act)
 	{
-		act=truth.inject(state,truth.compose(pre,act))
+		act=truth.compose(pre,act)
 		return act?new Promise(res=>res(truth.compose(post,act))):act
 	}//promise prevents holding up subsequent code
+	pre.push(act=>truth.inject(state,act))
 	send({type:'set',path:[],val:state})
 	return truth.proxy(send,state)
 }
-truth.compose=(fns,...args)=>fns.reduce((arg,fn)=>fn(...arg),args)
+truth.compose=(fns,arg)=>fns.reduce((arg,fn)=>fn(arg),arg)
 truth.inject=function(state,act)
 {
 	if(!act.type) return

--- a/truth.mjs
+++ b/truth.mjs
@@ -3,11 +3,11 @@ export default function truth(...ops)
 	let
 	i=ops.findIndex(x=>!(x instanceof Function)),
 	[pre,state,post]=truth.zipList(ops,i),
-	send=function(act)
+	send=function(act)//promise return prevents holding up subsequent code
 	{
 		act=truth.compose(pre,act)
 		return act?new Promise(res=>res(truth.compose(post,act))):act
-	}//promise prevents holding up subsequent code
+	}
 	pre.push(act=>truth.inject(state,act))
 	send({type:'set',path:[],val:state})
 	return truth.proxy(send,state)

--- a/truth.mjs
+++ b/truth.mjs
@@ -3,17 +3,16 @@ export default function truth(...ops)
 	let
 	i=ops.findIndex(x=>!(x instanceof Function)),
 	[pre,state,post]=truth.zipList(ops,i),
-	mk=(act,op)=>op(act),
 	send=function(act)
 	{
-		act=pre.reduce(mk,act)
-		truth.inject(state,act)
-		return new Promise(pass=>pass(post.reduce(mk,act)))
+		act=truth.inject(state,truth.compose(pre,act))
+		return new Promise(res=>res(truth.compose(post,act)))
 	}//promise prevents holding up subsequent code
 	send({type:'set',path:[],val:state})
 	return truth.proxy(send,state)
 }
 truth.inject=function(state,{path,type,val})
+truth.compose=(fns,...args)=>fns.reduce((arg,fn)=>fn(...arg),args)
 {
 	if(!type) return
 	const


### PR DESCRIPTION
Exposed the logic that that interprets proxy trap returns in truth.inject(), which applies the correct type of action (get,set,delete) to the proxy target (e.g. proxy.prop='value'creates a delta object {path:['prop'], type:'set', val:'value' }). 