### PR TITLE
Truthy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ This library can be used to create nested proxies when sub-properties are access
 
 Example:
 
-`const state=truth(validate,{initalValue},sendChangeToServer)`
+`const {state}=truth(validate,{initalValue},sendChangeToServer)`

--- a/tests.html
+++ b/tests.html
@@ -6,7 +6,7 @@
 	equal=(a,b)=>JSON.stringify(a)===JSON.stringify(b),
 	recordHistory=(history=[])=>({history,listener:x=>(history.push(x),x)}),
 	{history,listener:recorder}=recordHistory(),
-	write=truth(recorder,read),
+	write=truth(recorder,read).state,
 	expected=
 	{
 		counter:1,
@@ -27,4 +27,8 @@
 	write.public.tabs.push('start','middle','end')
 	write.public.tabs.splice(1,1)
 	equal(read,expected)?console.log('tests passed'):console.error('tests failed')
+
+	// const tmp=truth.y({value:1},console.log)
+	// tmp.update({from:'server',type:'set',path:['value'],val:2})
+	// console.log(tmp.state)
 </script>

--- a/truth.mjs
+++ b/truth.mjs
@@ -37,6 +37,6 @@ truth.y=function(...ops)
 		return act?new Promise(res=>res(truth.compose(post,act))):act
 	}
 	send({type:'set',path:[],val:state})
-	return {state:truth.proxy(send,state)}
+	return {pre,state:truth.proxy(send,state),post,update:send}
 }
 truth.zipList=(x,i)=>[x.slice(0,i),x[i],x.slice(i+1)]

--- a/truth.mjs
+++ b/truth.mjs
@@ -1,16 +1,6 @@
 export default function truth(...ops)
 {
-	let
-	i=ops.findIndex(x=>!(x instanceof Function)),
-	[pre,state,post]=truth.zipList(ops,i),
-	send=function(act)//promise return prevents holding up subsequent code
-	{
-		act=truth.compose(pre,act)
-		return act?new Promise(res=>res(truth.compose(post,act))):act
-	}
-	pre.push(act=>truth.inject(state,act))
-	send({type:'set',path:[],val:state})
-	return truth.proxy(send,state)
+	return truth.y(...ops)
 }
 truth.compose=(fns,arg)=>fns.reduce((arg,fn)=>fn(arg),arg)
 truth.inject=function(state,act)
@@ -36,4 +26,18 @@ truth.proxy=function(send,obj,path=[])
 	}):obj
 }
 truth.ref=(ref,path)=>path.reduce((ref,prop)=>ref[prop],ref)
+truth.y=function(...ops)
+{
+	let
+	i=ops.findIndex(x=>!(x instanceof Function)),
+	[pre,state,post]=truth.zipList(ops,i),
+	send=function(act)//promise return prevents holding up subsequent code
+	{
+		act=truth.compose(pre,act)
+		return act?new Promise(res=>res(truth.compose(post,act))):act
+	}
+	pre.push(act=>truth.inject(state,act))
+	send({type:'set',path:[],val:state})
+	return truth.proxy(send,state)
+}
 truth.zipList=(x,i)=>[x.slice(0,i),x[i],x.slice(i+1)]

--- a/truth.mjs
+++ b/truth.mjs
@@ -33,12 +33,10 @@ truth.y=function(...ops)
 	[pre,state,post]=truth.zipList(ops,i),
 	send=function(act)//promise return prevents holding up subsequent code
 	{
-		act=truth.compose(pre,act)
+		act=truth.compose([...pre,act=>truth.inject(state,act)],act)
 		return act?new Promise(res=>res(truth.compose(post,act))):act
 	}
-	pre.push(act=>truth.inject(state,act))
 	send({type:'set',path:[],val:state})
-	return truth.proxy(send,state)
 	return {state:truth.proxy(send,state)}
 }
 truth.zipList=(x,i)=>[x.slice(0,i),x[i],x.slice(i+1)]

--- a/truth.mjs
+++ b/truth.mjs
@@ -1,6 +1,6 @@
 export default function truth(...ops)
 {
-	return truth.y(...ops)
+	return truth.y(...ops).state
 }
 truth.compose=(fns,arg)=>fns.reduce((arg,fn)=>fn(arg),arg)
 truth.inject=function(state,act)
@@ -39,5 +39,6 @@ truth.y=function(...ops)
 	pre.push(act=>truth.inject(state,act))
 	send({type:'set',path:[],val:state})
 	return truth.proxy(send,state)
+	return {state:truth.proxy(send,state)}
 }
 truth.zipList=(x,i)=>[x.slice(0,i),x[i],x.slice(i+1)]


### PR DESCRIPTION
Changed truth's return value to {pre,state:proxy,post,update} instead of just proxy to allow more fine-grained control over pre, post, and all operations (e.g. let chant.js directly pass in a change and keep the from property to prevent the post operation sync function from resubmitting the change to the server). 